### PR TITLE
Issue #1 - Fix hook_config_info

### DIFF
--- a/devel_generate_text_settings.module
+++ b/devel_generate_text_settings.module
@@ -13,6 +13,7 @@ function devel_generate_text_settings_config_info() {
     'label' => t('Devel generate text settings'),
     'group' => t('Configuration'),
   );
+  return $prefixes;
 }
 
 /**


### PR DESCRIPTION
Fixes #1 
Adds `return $prefixes;` to bottom of the function.